### PR TITLE
Add test to run evaluation script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.10-slim-buster
+
+RUN apt-get update && apt-get install -y \
+    make \
+    awscli \
+    git \
+    build-essential
+
+RUN pip install --upgrade pip
+
+WORKDIR /app/GCL
+COPY . .
+
+RUN pip install -r requirements.txt
+
+ENTRYPOINT ["python", "evals/eval_gs_v1.py"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest
+tox

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+beir==2.0.0
+braceexpand==0.1.7
+numpy==1.23.2
+open_clip_torch==2.23.0
+pandas==2.2.2
+# pytorch-cuda==11.7
+pytrec-eval==0.5
+torch==1.13.1
+torchvision==0.14.1
+webdataset==0.2.86

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -1,0 +1,96 @@
+import os
+import pytest
+import requests
+import tarfile
+import tempfile
+from evals.eval_gs_v1 import run_eval
+
+s3_bucket_url = "https://marqo-gcl-public.s3.amazonaws.com/gcl-test-data/tiny-dataset"
+
+@pytest.fixture(scope="session")
+def temp_dir():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        print(f"temp directory: {temp_dir}")
+        yield temp_dir
+        print(f"temp directory deleted: {temp_dir}")
+
+
+# Download a file from a URL and save it to temp_dir
+def download(temp_dir, url):
+    response = requests.get(url)
+    response.raise_for_status()  # Ensure we handle potential download errors
+    file_name = os.path.join(temp_dir, os.path.basename(url))
+    with open(file_name, "wb") as f:
+        f.write(response.content)
+    return file_name
+
+
+# Extract a tar file into temp_dir
+def extract_tar(temp_dir, file_path):
+    with tarfile.open(file_path, "r") as tar:
+        tar.extractall(path=temp_dir)
+
+
+# Replace a target string with a replacement string in a text file (assumes the file is small enough to fit in memory)
+def replace_string_in_file(file_path, target_string, replacement_string):
+    # Read the contents of the file
+    with open(file_path, "r") as file:
+        file_contents = file.read()
+
+    modified_contents = file_contents.replace(target_string, replacement_string)
+
+    # Write the modified contents back to the file
+    with open(file_path, "w") as file:
+        file.write(modified_contents)
+
+
+@pytest.fixture(scope="session")
+def test_csv_path(temp_dir):
+    test_csv_path = download(temp_dir, f"{s3_bucket_url}/query_tiny.csv")
+    # update image paths as GCL expects full paths
+    replace_string_in_file(test_csv_path, '","images/', f'","{temp_dir}/images/')
+    return test_csv_path
+
+
+@pytest.fixture(scope="session")
+def doc_meta_path(temp_dir):
+    doc_meta_path = download(temp_dir, f"{s3_bucket_url}/corpus_tiny.json")
+    # update image paths as GCL expects full paths
+    replace_string_in_file(
+        doc_meta_path, '"image_local":"images/', f'"image_local": "{temp_dir}/images/'
+    )
+    return doc_meta_path
+
+
+@pytest.fixture(scope="session")
+def pretrained_path(temp_dir):
+    return download(temp_dir, f"{s3_bucket_url}/marqo-gcl-vitl14-124-gs-full_states.pt")
+
+
+@pytest.fixture(scope="session")
+def images_path(temp_dir):
+    return extract_tar(temp_dir, download(temp_dir, f"{s3_bucket_url}/images.tar"))
+
+
+def test_run_eval( temp_dir, pretrained_path: str, test_csv_path: str, doc_meta_path: str, images_path: str):
+    result = run_eval(["--model_name", "ViT-L-14",
+            "--test_csv", test_csv_path,
+            "--doc-meta", doc_meta_path,
+            "--weight_key", "score_linear",
+            "--output-dir", f'{temp_dir}/output',
+            "--pretrained", pretrained_path,
+            "--batch-size", "512",
+            "--num_workers", "2",
+            "--left-key", "['query']",
+            "--right-key", "['image_local']",
+            "--img-or-txt", "[['txt'], ['img']]",
+            "--left-weight", "[1]",
+            "--right-weight", "[1]",
+            "--context-length", "[[77], [0]]",
+            "--top-q", "15"])
+    # due to stochastic nature of the evaluation, we can't assert the exact values in the result so we'll just do
+    # some basic checks:
+    assert result, "The result should not be empty"
+    assert isinstance(result, dict), "The result should be a dictionary"
+    assert 'summary' in result, "The dictionary should have a 'summary' key"
+    assert result['summary'], "The 'summary' key should not have an empty result"

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+# tox.ini
+[tox]
+envlist = py310
+skipsdist = True
+
+[testenv]
+deps = -rrequirements-dev.txt
+setenv = PYTHONPATH = {toxinidir}
+commands = pytest tests/


### PR DESCRIPTION
Simple test just to sanity check that the eval script is runnable with
expected arguments. The test downloads a fixed dataset from S3 to run
the evaluation.

Refactored eval_gs_v1.py script to give it an entry function that can be
tested.
